### PR TITLE
Fix Windows build & add Windows support to GitHub Action workflow.

### DIFF
--- a/.github/workflows/build-Dubber.yml
+++ b/.github/workflows/build-Dubber.yml
@@ -34,6 +34,10 @@ jobs:
             os: ubuntu-latest
             pluginval-binary: ./pluginval
             ccache: ccache
+          - name: Windows
+            os: windows-2022
+            pluginval-binary: .\pluginval.exe
+            ccache: ccache
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
@@ -75,10 +79,23 @@ jobs:
         p12-file-base64: ${{ secrets.DEV_ID_APP_CERT }}
         p12-password: ${{ secrets.DEV_ID_APP_PASSWORD }}
 
-    - name: Configure
+    - name: Configure (macOS)
+      if: ${{ matrix.name == 'macOS' }}
       shell: bash
       working-directory: ${{env.PROJECT_DIR}}
       run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" .
+
+    - name: Configure (Linux)
+      if: ${{ matrix.name == 'Linux' }}
+      shell: bash
+      working-directory: ${{env.PROJECT_DIR}}
+      run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} .
+
+    - name: Configure (Windows)
+      if: ${{ matrix.name == 'Windows' }}
+      shell: bash
+      working-directory: ${{env.PROJECT_DIR}}
+      run: cmake -B ${{ env.BUILD_DIR }} -G 'Visual Studio 17 2022' -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} .
 
     - name: Build
       shell: bash
@@ -109,7 +126,6 @@ jobs:
       uses: coactions/setup-xvfb@v1
       with:
         working-directory: ${{ env.PROJECT_BUILD_DIR }}
-        shell: bash
         run: |
           curl -LO "https://github.com/Tracktion/pluginval/releases/download/v1.0.3/pluginval_${{ matrix.name }}.zip"
           7z x pluginval_${{ matrix.name }}.zip

--- a/.github/workflows/build-PullUpMachine.yml
+++ b/.github/workflows/build-PullUpMachine.yml
@@ -34,6 +34,10 @@ jobs:
             os: ubuntu-latest
             pluginval-binary: ./pluginval
             ccache: ccache
+          - name: Windows
+            os: windows-2022
+            pluginval-binary: .\pluginval.exe
+            ccache: ccache
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
@@ -75,10 +79,23 @@ jobs:
         p12-file-base64: ${{ secrets.DEV_ID_APP_CERT }}
         p12-password: ${{ secrets.DEV_ID_APP_PASSWORD }}
 
-    - name: Configure
+    - name: Configure (macOS)
+      if: ${{ matrix.name == 'macOS' }}
       shell: bash
       working-directory: ${{env.PROJECT_DIR}}
       run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" .
+
+    - name: Configure (Linux)
+      if: ${{ matrix.name == 'Linux' }}
+      shell: bash
+      working-directory: ${{env.PROJECT_DIR}}
+      run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} .
+
+    - name: Configure (Windows)
+      if: ${{ matrix.name == 'Windows' }}
+      shell: bash
+      working-directory: ${{env.PROJECT_DIR}}
+      run: cmake -B ${{ env.BUILD_DIR }} -G 'Visual Studio 17 2022' -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} .
 
     - name: Build
       shell: bash
@@ -109,7 +126,6 @@ jobs:
       uses: coactions/setup-xvfb@v1
       with:
         working-directory: ${{ env.PROJECT_BUILD_DIR }}
-        shell: bash
         run: |
           curl -LO "https://github.com/Tracktion/pluginval/releases/download/v1.0.3/pluginval_${{ matrix.name }}.zip"
           7z x pluginval_${{ matrix.name }}.zip

--- a/.github/workflows/build-SimpleClip.yml
+++ b/.github/workflows/build-SimpleClip.yml
@@ -34,6 +34,10 @@ jobs:
             os: ubuntu-latest
             pluginval-binary: ./pluginval
             ccache: ccache
+          - name: Windows
+            os: windows-2022
+            pluginval-binary: .\pluginval.exe
+            ccache: ccache
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
@@ -75,10 +79,23 @@ jobs:
         p12-file-base64: ${{ secrets.DEV_ID_APP_CERT }}
         p12-password: ${{ secrets.DEV_ID_APP_PASSWORD }}
 
-    - name: Configure
+    - name: Configure (macOS)
+      if: ${{ matrix.name == 'macOS' }}
       shell: bash
       working-directory: ${{env.PROJECT_DIR}}
       run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" .
+
+    - name: Configure (Linux)
+      if: ${{ matrix.name == 'Linux' }}
+      shell: bash
+      working-directory: ${{env.PROJECT_DIR}}
+      run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} .
+
+    - name: Configure (Windows)
+      if: ${{ matrix.name == 'Windows' }}
+      shell: bash
+      working-directory: ${{env.PROJECT_DIR}}
+      run: cmake -B ${{ env.BUILD_DIR }} -G 'Visual Studio 17 2022' -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} .
 
     - name: Build
       shell: bash
@@ -109,7 +126,6 @@ jobs:
       uses: coactions/setup-xvfb@v1
       with:
         working-directory: ${{ env.PROJECT_BUILD_DIR }}
-        shell: bash
         run: |
           curl -LO "https://github.com/Tracktion/pluginval/releases/download/v1.0.3/pluginval_${{ matrix.name }}.zip"
           7z x pluginval_${{ matrix.name }}.zip

--- a/.github/workflows/build-SimpleSub.yml
+++ b/.github/workflows/build-SimpleSub.yml
@@ -34,6 +34,10 @@ jobs:
             os: ubuntu-latest
             pluginval-binary: ./pluginval
             ccache: ccache
+          - name: Windows
+            os: windows-2022
+            pluginval-binary: .\pluginval.exe
+            ccache: ccache
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
@@ -75,10 +79,23 @@ jobs:
         p12-file-base64: ${{ secrets.DEV_ID_APP_CERT }}
         p12-password: ${{ secrets.DEV_ID_APP_PASSWORD }}
 
-    - name: Configure
+    - name: Configure (macOS)
+      if: ${{ matrix.name == 'macOS' }}
       shell: bash
       working-directory: ${{env.PROJECT_DIR}}
       run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" .
+
+    - name: Configure (Linux)
+      if: ${{ matrix.name == 'Linux' }}
+      shell: bash
+      working-directory: ${{env.PROJECT_DIR}}
+      run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} .
+
+    - name: Configure (Windows)
+      if: ${{ matrix.name == 'Windows' }}
+      shell: bash
+      working-directory: ${{env.PROJECT_DIR}}
+      run: cmake -B ${{ env.BUILD_DIR }} -G 'Visual Studio 17 2022' -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache }} .
 
     - name: Build
       shell: bash
@@ -109,7 +126,6 @@ jobs:
       uses: coactions/setup-xvfb@v1
       with:
         working-directory: ${{ env.PROJECT_BUILD_DIR }}
-        shell: bash
         run: |
           curl -LO "https://github.com/Tracktion/pluginval/releases/download/v1.0.3/pluginval_${{ matrix.name }}.zip"
           7z x pluginval_${{ matrix.name }}.zip

--- a/Dubber/Source/Siren.h
+++ b/Dubber/Source/Siren.h
@@ -219,7 +219,7 @@ private:
         v++;
         int tableLen = v * 2;
         
-        double ar[tableLen], ai[tableLen];
+        double *ar = new double[tableLen](), *ai = new double[tableLen]();
         
         double topFreq = baseFrequency * 2.0 / sampleRate;
         double scale = 0.0;
@@ -230,6 +230,9 @@ private:
             if (tableLen > 999999)
                 tableLen >>= 1;
         }
+        
+        delete[] ar;
+        delete[] ai;
     }
     
     void defineSawtooth(int len, int numHarmonics, double* ar, double* ai)
@@ -269,13 +272,16 @@ private:
             scale = 1.0 / max * 0.999;
         }
         
-        float wave[len];
+        float *wave = new float[len]();
+        
         for (int idx=0; idx < len; idx++) {
             wave[idx] = ai[idx] * scale;
         }
         
         if (addWaveTable(len, wave, topFreq))
             scale = 0.0;
+        
+        delete[] wave;
         
         return scale;
     }
@@ -333,8 +339,8 @@ private:
             LE *= 2;                          // (LE = 2^L)
             Ur = 1.0;
             Ui = 0.;
-            Wr = cos(M_PI/(float)LE1);
-            Wi = -sin(M_PI/(float)LE1); // Cooley, Lewis, and Welch have "+" here
+            Wr = cos(juce::MathConstants<float>::pi /(float)LE1);
+            Wi = -sin(juce::MathConstants<float>::pi /(float)LE1); // Cooley, Lewis, and Welch have "+" here
             for (j = 1; j <= LE1; j++) {
                 for (i = j; i <= N; i += LE) { // butterfly
                     ip = i+LE1;


### PR DESCRIPTION
- Fix Dubber build errors when targetting Windows, which were caused by use of a dynamically sized stack array and a missing PI define.
- Enable Windows for GitHub Actions workflow, which required splitting out steps into platform specific ones. In particular Windows must use a Visual Studio CMake generator instead of Ninja.

![image](https://github.com/dar-io-p/PotenzaDSP/assets/18558188/5b35b1ba-63fc-43e2-8314-4f7cb89b4580)